### PR TITLE
Remove userId usage for ativity history

### DIFF
--- a/e2e/3_1_Stories_Bugs.postman_collection.json
+++ b/e2e/3_1_Stories_Bugs.postman_collection.json
@@ -10988,11 +10988,6 @@
 											"    pm.expect(data.events[0].principal.name).to.eql(pm.variables.replaceIn(\"{{apihub_api_key_name}}\"));\r",
 											"    pm.expect(data.events[0].principal.id).to.eql(pm.variables.replaceIn(\"{{apihub_api_key_id}}\"));\r",
 											"    pm.expect(data.events[0].principal.type).to.eql('apiKey');\r",
-											"});\r",
-											"\r",
-											"\r",
-											"pm.test(\"'userId' is correct\", function () {\r",
-											"    pm.expect(data.events[0].userId).to.eql(pm.variables.replaceIn('{{apihub_api_key_id}}'));\r",
 											"});"
 										]
 									}
@@ -11207,11 +11202,6 @@
 											"    pm.expect(data.events[0].principal.name).to.eql(pm.variables.replaceIn(\"{{apihub_api_key_name}}\"));\r",
 											"    pm.expect(data.events[0].principal.id).to.eql(pm.variables.replaceIn(\"{{apihub_api_key_id}}\"));\r",
 											"    pm.expect(data.events[0].principal.type).to.eql('apiKey');\r",
-											"});\r",
-											"\r",
-											"\r",
-											"pm.test(\"'userId' is correct\", function () {\r",
-											"    pm.expect(data.events[0].userId).to.eql(pm.variables.replaceIn('{{apihub_api_key_id}}'));\r",
 											"});"
 										]
 									}
@@ -11426,11 +11416,6 @@
 											"    pm.expect(data.events[0].principal.name).to.eql(pm.variables.replaceIn(\"{{apihub_api_key_name}}\"));\r",
 											"    pm.expect(data.events[0].principal.id).to.eql(pm.variables.replaceIn(\"{{apihub_api_key_id}}\"));\r",
 											"    pm.expect(data.events[0].principal.type).to.eql('apiKey');\r",
-											"});\r",
-											"\r",
-											"\r",
-											"pm.test(\"'userId' is correct\", function () {\r",
-											"    pm.expect(data.events[0].userId).to.eql(pm.variables.replaceIn('{{apihub_api_key_id}}'));\r",
 											"});"
 										]
 									}
@@ -11557,11 +11542,6 @@
 											"    pm.expect(data.events[0].principal.name).to.eql(pm.variables.replaceIn(\"{{apihub_api_key_name}}\"));\r",
 											"    pm.expect(data.events[0].principal.id).to.eql(pm.variables.replaceIn(\"{{apihub_api_key_id}}\"));\r",
 											"    pm.expect(data.events[0].principal.type).to.eql('apiKey');\r",
-											"});\r",
-											"\r",
-											"\r",
-											"pm.test(\"'userId' is correct\", function () {\r",
-											"    pm.expect(data.events[0].userId).to.eql(pm.variables.replaceIn('{{apihub_api_key_id}}'));\r",
 											"});"
 										]
 									}
@@ -11621,7 +11601,6 @@
 											"            pm.expect(data.events[i].principal.id).to.include(pm.variables.replaceIn('{{apihub_api_key_id}}'));\r",
 											"            pm.expect(data.events[i].principal.name).to.eql(pm.variables.replaceIn('{{apihub_api_key_name}}'));\r",
 											"            pm.expect(data.events[i].principal.type).to.eql(\"apiKey\");\r",
-											"            pm.expect(data.events[i].userId).to.eql(pm.variables.replaceIn('{{apihub_api_key_id}}'));\r",
 											"        }\r",
 											"    }\r",
 											"});"


### PR DESCRIPTION
Response for activity history was not compliant with the API spec. `userId` field was redundant in the response, a corresponding fix has been made in the backend, adaptation of postman collections is also required.