### PR TITLE
Normalize public contacts and examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Please, follow these guidelines to make the contribution process easy and effect
 
 ## Contributor License Agreement
 
-You must sign the [Contributor License Agreement](https://pages.netcracker.com/cla-main.html) in order to contribute.
+You must sign the [Contributor License Agreement](https://github.com/Netcracker/qubership-workflow-hub/blob/main/CLA/cla.md) in order to contribute.
 
 ## Code of Conduct
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,13 @@
-# Security Reporting Process
+# Security Policy
+
+## Reporting a Vulnerability
 
 Please, report any security issue to `opensourcegroup@netcracker.com` where the issue will be triaged appropriately.
 
 If you know of a publicly disclosed security vulnerability please IMMEDIATELY email `opensourcegroup@netcracker.com`
 to inform the team about the vulnerability, so we may start the patch, release, and communication process.
 
-# Security Release Process
+## Security Release Process
 
 If the vulnerability is found in the latest stable release, then it would be fixed in patch version for that release.
 E.g., issue is found in 2.5.0 release, then 2.5.1 version with a fix will be released.

--- a/e2e/2_1_Negative_Portal.postman_collection.json
+++ b/e2e/2_1_Negative_Portal.postman_collection.json
@@ -4522,9 +4522,9 @@
                                             "});",
                                             "",
                                             "var data = JSON.parse(responseBody);",
-                                            "pm.environment.set(\"runenvEmail\", \"runenv.surname@qubership.org\");",
+                                            "pm.environment.set(\"runenvEmail\", \"runenv.surname@example.com\");",
                                             "pm.environment.set(\"runenvPassword\", \"pa$$word\");",
-                                            "pm.environment.set(\"runenvId\",  \"runenv-surnameatqubership-org\");"
+                                            "pm.environment.set(\"runenvId\",  \"runenv-surnameatexample-com\");"
                                         ]
                                     }
                                 },
@@ -4554,7 +4554,7 @@
                                 "header": [],
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\r\n  \"email\": \"runenv.surname@qubership.org\",\r\n  \"name\": \"RUNENV RUNENV\",\r\n  \"password\": \"pa$$word\",\r\n  \"privateWorkspaceId\": \"\"\r\n}",
+                                    "raw": "{\r\n  \"email\": \"runenv.surname@example.com\",\r\n  \"name\": \"RUNENV RUNENV\",\r\n  \"password\": \"pa$$word\",\r\n  \"privateWorkspaceId\": \"\"\r\n}",
                                     "options": {
                                         "raw": {
                                             "language": "json"

--- a/e2e/4_Access_control.postman_collection.json
+++ b/e2e/4_Access_control.postman_collection.json
@@ -571,7 +571,7 @@
                                 "header": [],
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\r\n    \"email\": \"user1@openmail.com\",\r\n    \"password\": \"password\",\r\n    \"name\": \"AC_user_1\"\r\n}",
+                                    "raw": "{\r\n    \"email\": \"user1@example.com\",\r\n    \"password\": \"password\",\r\n    \"name\": \"AC_user_1\"\r\n}",
                                     "options": {
                                         "raw": {
                                             "language": "json"
@@ -638,7 +638,7 @@
                                 "header": [],
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\r\n    \"email\": \"user2@openmail.com\",\r\n    \"password\": \"password\",\r\n    \"name\": \"AC_user_2\"\r\n}",
+                                    "raw": "{\r\n    \"email\": \"user2@example.com\",\r\n    \"password\": \"password\",\r\n    \"name\": \"AC_user_2\"\r\n}",
                                     "options": {
                                         "raw": {
                                             "language": "json"
@@ -705,7 +705,7 @@
                                 "header": [],
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\r\n    \"email\": \"user4@openmail.com\",\r\n    \"password\": \"password\",\r\n    \"name\": \"AC_user_4\"\r\n}",
+                                    "raw": "{\r\n    \"email\": \"user4@example.com\",\r\n    \"password\": \"password\",\r\n    \"name\": \"AC_user_4\"\r\n}",
                                     "options": {
                                         "raw": {
                                             "language": "json"
@@ -772,7 +772,7 @@
                                 "header": [],
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\r\n    \"email\": \"user5@openmail.com\",\r\n    \"password\": \"password\",\r\n    \"name\": \"AC_user_5\"\r\n}",
+                                    "raw": "{\r\n    \"email\": \"user5@example.com\",\r\n    \"password\": \"password\",\r\n    \"name\": \"AC_user_5\"\r\n}",
                                     "options": {
                                         "raw": {
                                             "language": "json"

--- a/environment/Env1.postman_environment.json
+++ b/environment/Env1.postman_environment.json
@@ -31,7 +31,7 @@
                 "type": "text/plain"
             },
             "type": "any",
-            "value": "x_apihub@openmail.com",
+            "value": "x_apihub@example.com",
             "key": "User_email"
         },
         {


### PR DESCRIPTION
## Summary

- Normalize public contact files and example email addresses.
- Keep API support and repository feedback contacts aligned with approved addresses.
- Replace personal-looking examples with neutral example data where applicable.

## Changed files

- CONTRIBUTING.md
- SECURITY.md
- e2e/2_1_Negative_Portal.postman_collection.json
- e2e/4_Access_control.postman_collection.json
- environment/Env1.postman_environment.json

## Commit

4eb0563 chore: normalize public contacts and examples
 CONTRIBUTING.md                                 | 2 +-
 SECURITY.md                                     | 6 ++++--
 e2e/2_1_Negative_Portal.postman_collection.json | 6 +++---
 e2e/4_Access_control.postman_collection.json    | 8 ++++----
 environment/Env1.postman_environment.json       | 2 +-
 5 files changed, 13 insertions(+), 11 deletions(-)
