### PR TITLE
chore: release 26.3.1

### DIFF
--- a/e2e/1_1_Smoke_Portal.postman_collection.json
+++ b/e2e/1_1_Smoke_Portal.postman_collection.json
@@ -15264,8 +15264,13 @@
                                     "script": {
                                         "type": "text/javascript",
                                         "exec": [
-                                            "pm.test(\"Status code is 204\", function () {\r",
-                                            "    pm.response.to.have.status(204);\r",
+                                            "pm.test(\"Status code is 409\", function () {\r",
+                                            "    pm.response.to.have.status(409);\r",
+                                            "});\r",
+                                            "\r",
+                                            "var data = pm.response.json();\r",
+                                            "pm.test(\"There is dependent dashboard version\", function () {\r",
+                                            "    pm.expect(\"QS-STATIC-TEST-2.DSHB|2023.3@1\").to.eql(data.params.dashboards);\r",
                                             "});\r",
                                             ""
                                         ]
@@ -16011,7 +16016,7 @@
                                             "var data = pm.response.json();\r",
                                             "\r",
                                             "pm.test(\"There are 4 operations\", function () {\r",
-                                            "    pm.expect(data.operationTypes[0].operationsCount).to.eql(4);\r",
+                                            "    pm.expect(data.operationTypes[0].operationsCount).to.eql(6);\r",
                                             "});\r",
                                             "\r",
                                             "pm.test(\"'operationTypes' = rest\", function () {\r",


### PR DESCRIPTION
* chore: adopt tests to API key changes

* fix: remove redundant tests + fix version deletion tests

* fix: update group publish e2e tests

* fix: publish into real group in 4.2.16 invalid-kind test

* chore: add static_group_1 to Env1 environment

* fix: publish into workspace in 4.2.16 invalid-kind test

* update publish validation tests

---------